### PR TITLE
Adds more customization to the radar

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ tech-radar:
   ring: trial
   topic: Topic #Optional - will be appended to the name in the radar blip summary
   # Optional metadata hash - the keys and value will be listed in the radar blip summary
+  tags:
+  - one
+  - two
   metadata:
-    Tags: my tag, your tag
     MyKey: my value
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,31 @@ tech-radar:
   name: Vault
   quadrant: Tools
   ring: trial
+  topic: Topic #Optional - will be appended to the name in the radar blip summary
+  # Optional metadata hash - the keys and value will be listed in the radar blip summary
+  metadata:
+    Tags: my tag, your tag
+    MyKey: my value
 ---
 
 # Vault Secret Storage
+
+Vault is super secret.
+
+You should use it.
 ```
+
+The quadrant and ring will be used to decide where to place the blip. The name, metadata, and the first paragraph in
+the page will be used for the exandable summary area in the radar. The example above will look like:
+
+-------------------
+### Vault
+**Tags**: my tag, your tag  
+**MyKey**: my value
+
+Vault is super secret
+
+-------------------
 
 **NOTE:** There will be an error message on the generated radar if there are less than four quadrants represented in the pages' markdown files.
 
@@ -54,3 +75,18 @@ Specify an `{ "name": "index", ... }` format map of rings like so:
 ```
 
 The ring names in page front matter must match ring names in the plugin config.
+
+### Customize the radar header and footer content
+
+You can add your own headerImageHtml and footerHtml to override ThoughtWorks defaults
+```javascript
+{
+    "plugins": ["tech-radar"],
+    "pluginsConfig": {
+        "tech-radar": {
+            "footerHtml": "This is our radar. It is based on the <a href=\"https://www.thoughtworks.com/insights/blog/build-your-own-technology-radar\">enterprise tech radar article</a> by ThoughtWorks.",
+            "headerImageHtml": "<img src=\"https://example.com/logo.png\" />"
+        }
+    }
+}
+```

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack')
 var webpackBuild = require('./webpack.config.js')
 
-var descRegExp = new RegExp(/<p>(.+?)<\/p>/)
+var descRegExp = new RegExp(/<p>((?:.|\n)+?)<\/p>/)
 
 let radar = {
   blips: [],
@@ -25,9 +25,11 @@ module.exports = {
         if ( page['tech-radar'] ) {
           var result = descRegExp.exec(page.content)
           const blip = {
-            name: page.title,
-            description: (result != null && result.length > 0) ? result[0] : '',
+            name: page['tech-radar'].name || page.title,
+            description: ( result != null && result.length > 0 ) ? result[1] : '',
             ring: page['tech-radar'].ring,
+            metadata: page['tech-radar'].metadata && JSON.stringify(page['tech-radar'].metadata),
+            topic: page['tech-radar'].topic,
             quadrant: page['tech-radar'].quadrant,
             docLink: this.output.toURL(page.path),
             isNew: isBlipNew(page),
@@ -54,6 +56,8 @@ module.exports = {
         var config = this.config.get('pluginsConfig.tech-radar', {});
         radar.name = config.title
         radar.rings = config.rings
+        radar.footerHtml = config.footerHtml
+        radar.headerImageHtml = config.headerImageHtml
 
         var bookDir = this.output.resolve(".")
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gitbook-plugin-tech-radar",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/models/blip.js
+++ b/src/models/blip.js
@@ -1,4 +1,4 @@
-const Blip = function (name, ring, isNew, topic, description, docLink, tags) {
+const Blip = function (name, ring, isNew, topic, description, docLink, tags, metadata) {
   var self, number;
 
   self = {};
@@ -11,6 +11,14 @@ const Blip = function (name, ring, isNew, topic, description, docLink, tags) {
   self.topic = function () {
     return topic || '';
   };
+
+  self.metadata = function () {
+    if (metadata) {
+      return JSON.parse(metadata);
+    } else {
+      return {};
+    }
+  }
 
   self.description = function () {
     return description || '';

--- a/src/models/radar.js
+++ b/src/models/radar.js
@@ -8,7 +8,7 @@ const _ = {
 };
 
 const Radar = function() {
-  var self, quadrants, tags, blipNumber, addingQuadrant;
+  var self, quadrants, tags, blipNumber, addingQuadrant, footerHtml, headerImageHtml;
 
   blipNumber = 0;
   addingQuadrant = 0;
@@ -77,6 +77,22 @@ const Radar = function() {
   self.tags = function () {
     return tags;
   };
+
+  self.addFooterHtml = function (data) {
+    footerHtml = data;
+  };
+
+  self.footerHtml = function () {
+    return footerHtml;
+  };
+
+  self.addHeaderImageHtml = function (data) {
+    headerImageHtml = data;
+  };
+
+  self.headerImageHtml = function () {
+    return headerImageHtml;
+  }
 
   return self;
 };

--- a/src/util/factory.js
+++ b/src/util/factory.js
@@ -54,6 +54,8 @@ const JsonToRadar = function (name) {
             try {
 
                 name = RadarData.name;
+                var footerHtml = RadarData.footerHtml;
+                var headerImageHtml = RadarData.headerImageHtml;
 
                 var all = RadarData.blips;
                 var tags = RadarData.tags;
@@ -88,13 +90,19 @@ const JsonToRadar = function (name) {
                     if (!quadrants[blip.quadrant]) {
                         quadrants[blip.quadrant] = new Quadrant(_.capitalize(blip.quadrant));
                     }
-                    quadrants[blip.quadrant].add(new Blip(blip.name, ringMap[blip.ring], blip.isNew.toLowerCase() === 'true', blip.topic, blip.description, blip.docLink, blip.tags))
+                    quadrants[blip.quadrant].add(new Blip(blip.name, ringMap[blip.ring], blip.isNew.toLowerCase() === 'true', blip.topic, blip.description, blip.docLink, blip.tags, blip.metadata))
                 });
 
                 var radar = new Radar();
                 _.each(quadrants, function (quadrant) {
                     radar.addQuadrant(quadrant)
                 });
+                if (footerHtml) {
+                  radar.addFooterHtml(footerHtml)
+                }
+                if (headerImageHtml) {
+                  radar.addHeaderImageHtml(headerImageHtml);
+                }
 
 			radar.setTags(tags);
 


### PR DESCRIPTION
Hey! I found this plugin while looking for some other gitbook plugins and it just so happened that I spent a lot of time in May doing my own version of this same thing (gitbook-generating-radar). Mine is much worse, so I want to switch to yours - it's awesome!

I've made a few changes and additions:
* `name` is now used from the front matter, rather than relying on the summary link text. This is because my summaries are auto-generated and thus somewhat constrained. (Summary link text will be used if no `name` is present.)
* there's now an optional `metadata` frontmatter hash which can give some extra context for blips.
* I connected `topic` from the front matter - I saw it existed in TW radar and there's code to use it, so why not
* I've allowed you to set the `headerImageHtml` and `footerHtml`. It seemed odd for me to have the ThoughtWorks text that doesn't really fit if you're hosting it yourself.
* I've fixed an issue where if you had more than, say, 10 blips, no more blips will be added since every blip will overlap. There's now some very basic logic to allow slight overlapping depending on numbers. I just took a rough guess here and it works for us.